### PR TITLE
Add app icon SVG and update README project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ task-list/
 │   ├── style.css        # グローバルスタイル
 │   └── vite-env.d.ts    # Vite型定義
 ├── index.html           # HTMLエントリーポイント
+├── icon.svg             # リポジトリ用アイコン（SVG）
 ├── package.json         # プロジェクト設定
 ├── tsconfig.json        # TypeScript設定
 ├── vite.config.ts       # Vite設定

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Task List App Icon</title>
+  <desc id="desc">Rounded square icon with a clipboard and three checklist items, representing a task list.</desc>
+
+  <rect x="16" y="16" width="224" height="224" rx="52" fill="#4f46e5"/>
+
+  <rect x="68" y="56" width="120" height="150" rx="18" fill="#ffffff" opacity="0.96"/>
+  <rect x="94" y="42" width="68" height="26" rx="12" fill="#dbeafe"/>
+  <rect x="110" y="48" width="36" height="8" rx="4" fill="#6366f1"/>
+
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="8">
+    <rect x="84" y="86" width="18" height="18" rx="4" stroke="#22c55e"/>
+    <path d="M87 95l6 6 10-12" stroke="#22c55e"/>
+    <line x1="112" y1="95" x2="168" y2="95" stroke="#334155"/>
+
+    <rect x="84" y="122" width="18" height="18" rx="4" stroke="#22c55e"/>
+    <path d="M87 131l6 6 10-12" stroke="#22c55e"/>
+    <line x1="112" y1="131" x2="160" y2="131" stroke="#334155"/>
+
+    <rect x="84" y="158" width="18" height="18" rx="4" stroke="#f59e0b"/>
+    <line x1="112" y1="167" x2="152" y2="167" stroke="#334155"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Add a repository/app icon asset and document it in `README.md` so the project has a visible SVG icon.

### Description
- Add `icon.svg` that draws a rounded-square clipboard with checklist graphics, and update `README.md` to include `icon.svg` in the project structure.

### Testing
- No automated tests were run for this non-functional asset change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d92311ac832cb888a7628da15a45)