### PR TITLE
feat: GitHub Pages PR プレビューを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: リポジトリのチェックアウト
@@ -34,21 +32,8 @@ jobs:
       - name: ビルド
         run: npm run build
 
-      - name: GitHub Pagesのセットアップ
-        uses: actions/configure-pages@v4
-
-      - name: アーティファクトのアップロード
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist'
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: GitHub Pagesへのデプロイ
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          clean-exclude: pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,42 @@
+name: PRプレビュー
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v4
+
+      - name: Node.jsのセットアップ
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 依存関係のインストール
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: ビルド（PRプレビュー用パス）
+        if: github.event.action != 'closed'
+        run: npm run build
+        env:
+          VITE_BASE_URL: /task-list/pr-preview/pr-${{ github.event.pull_request.number }}/
+
+      - name: PRプレビューのデプロイ・削除
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: '/task-list/',
+  base: process.env.VITE_BASE_URL ?? '/task-list/',
 })


### PR DESCRIPTION
## 概要

PR が開かれるたびに GitHub Pages 上にプレビュー環境をデプロイし、マージ・クローズ時に自動削除する仕組みを追加します。

## 変更内容

### `vite.config.ts`
- `VITE_BASE_URL` 環境変数でベースパスを動的に設定できるよう変更
- 本番: `/task-list/`（デフォルト）
- PR プレビュー: `/task-list/pr-preview/pr-{番号}/`

### `.github/workflows/deploy.yml`
- `actions/deploy-pages` → `JamesIves/github-pages-deploy-action@v4` に切り替え
- `clean-exclude: pr-preview` により、本番デプロイ時に PR プレビューのディレクトリを消さないよう設定

### `.github/workflows/pr-preview.yml`（新規）
- `pull_request` イベント（opened / synchronize / reopened / closed）をトリガー
- PR が開いている間: PR ごとのベースパスでビルド → `gh-pages` ブランチの `pr-preview/pr-{番号}/` にデプロイ
- PR クローズ時: プレビューディレクトリを自動削除
- `rossjrw/pr-preview-action@v1` が PR にプレビュー URL のコメントを自動投稿

## プレビュー URL の形式

```
https://keigo-hisazumi.github.io/task-list/pr-preview/pr-{PR番号}/
```

## マージ後に必要な設定変更

> **重要**: このワークフローは `gh-pages` ブランチを使って GitHub Pages を配信します。  
> リポジトリの Pages 設定を以下のように変更してください。
>
> **Settings > Pages > Build and deployment > Source**  
> `GitHub Actions` → `Deploy from a branch`（ブランチ: `gh-pages`、フォルダ: `/ (root)`）

## テスト計画

- [ ] このPR自体のプレビューが `https://keigo-hisazumi.github.io/task-list/pr-preview/pr-{番号}/` に表示される
- [ ] Pages 設定変更後、`main` への push で本番デプロイが動作する
- [ ] PR クローズ後にプレビューディレクトリが削除される

---
_Generated by [Claude Code](https://claude.ai/code/session_0157if2XZd7cGPwDvhpJY7Nb)_