### PR TITLE
fix: iPhoneホーム画面から開くと404エラーになる問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Todoリスト</title>
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="./manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Todo" />
     <meta name="theme-color" content="#4f46e5" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" />
+    <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="./apple-touch-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="167x167" href="./apple-touch-icon-167x167.png" />
   </head>
   <body>
     <div id="app"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,18 +2,19 @@
   "name": "Todoリスト",
   "short_name": "Todo",
   "description": "シンプルなタスク管理アプリ",
-  "start_url": "/",
+  "start_url": "/task-list/",
+  "scope": "/task-list/",
   "display": "standalone",
   "background_color": "#4f46e5",
   "theme_color": "#4f46e5",
   "icons": [
     {
-      "src": "/pwa-icon-192x192.png",
+      "src": "/task-list/pwa-icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/pwa-icon-512x512.png",
+      "src": "/task-list/pwa-icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## 問題

iPhoneのホーム画面に追加してアイコンから開くと404エラーが発生する。

## 原因

`public/manifest.json` の `start_url` が `/` に設定されていたが、アプリは GitHub Pages の `/task-list/` にデプロイされている。iOSがホーム画面アプリを起動する際は `start_url` を使用するため、ルート `/` にアクセスして404が発生していた。

また、マニフェスト内のアイコンパスも `/pwa-icon-*.png` という絶対パスになっており、正しい `/task-list/pwa-icon-*.png` を指していなかった。

## 修正内容

- `manifest.json`: `start_url` を `/task-list/` に修正
- `manifest.json`: `scope` を `/task-list/` に追加
- `manifest.json`: アイコンの `src` パスを `/task-list/` プレフィックス付きに修正
- `index.html`: manifest・apple-touch-icon のリンクを絶対パス (`/`) から相対パス (`./`) に変更（Viteのベースパス処理に依存しない形に統一）

## テスト手順

1. デプロイ後、`https://keigo-hisazumi.github.io/task-list/` をiPhoneのSafariで開く
2. 「ホーム画面に追加」でアイコンを追加
3. ホーム画面のアイコンをタップして正常に起動することを確認

https://claude.ai/code/session_01AUzerEcTzNkcau3zP4EeGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUzerEcTzNkcau3zP4EeGd)_