### PR TITLE
UIレイアウト改善: ヘッダー・進捗バー・FAB・スライドアップパネル

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth'
 import {
   collection,
@@ -25,8 +25,14 @@ const currentUser = ref<User | null>(null)
 const authLoading = ref(true)
 const todos = ref<TodoItem[]>([])
 const newTodoText = ref('')
+const showAddPanel = ref(false)
 
 let unsubscribeTodos: (() => void) | null = null
+
+const completedCount = computed(() => todos.value.filter(t => t.completed).length)
+const progressPercent = computed(() =>
+  todos.value.length === 0 ? 0 : Math.round((completedCount.value / todos.value.length) * 100)
+)
 
 const subscribeTodos = (uid: string) => {
   const todosRef = collection(db, 'users', uid, 'todos')
@@ -42,13 +48,13 @@ const subscribeTodos = (uid: string) => {
 
 const addTodo = async () => {
   if (!currentUser.value || newTodoText.value.trim() === '') return
-
   await addDoc(collection(db, 'users', currentUser.value.uid, 'todos'), {
     text: newTodoText.value.trim(),
     completed: false,
     createdAt: serverTimestamp(),
   })
   newTodoText.value = ''
+  showAddPanel.value = false
 }
 
 const deleteTodo = async (id: string) => {
@@ -68,6 +74,16 @@ const toggleTodo = async (id: string) => {
 
 const logout = async () => {
   await signOut(auth)
+}
+
+const openAddPanel = () => {
+  showAddPanel.value = true
+  newTodoText.value = ''
+}
+
+const closeAddPanel = () => {
+  showAddPanel.value = false
+  newTodoText.value = ''
 }
 
 let unsubscribeAuth: (() => void) | null = null
@@ -103,24 +119,27 @@ onUnmounted(() => {
   <AuthForm v-else-if="!currentUser" />
 
   <div v-else class="todo-app">
-    <div class="app-header">
+    <!-- 固定ヘッダー -->
+    <header class="app-header">
       <h1>📝 Todoリスト</h1>
       <div class="user-info">
         <span class="user-email">{{ currentUser.email }}</span>
         <button class="logout-btn" @click="logout">ログアウト</button>
       </div>
+    </header>
+
+    <!-- 進捗エリア -->
+    <div class="progress-section">
+      <div class="progress-labels">
+        <span>進捗 {{ progressPercent }}%</span>
+        <span>{{ completedCount }} / {{ todos.length }} 完了</span>
+      </div>
+      <div class="progress-bar-track">
+        <div class="progress-bar-fill" :style="{ width: progressPercent + '%' }"></div>
+      </div>
     </div>
 
-    <div class="todo-input">
-      <input
-        v-model="newTodoText"
-        type="text"
-        placeholder="新しいタスクを入力..."
-        @keyup.enter="addTodo"
-      />
-      <button @click="addTodo">追加</button>
-    </div>
-
+    <!-- タスクリスト -->
     <div class="todo-list">
       <div
         v-for="todo in todos"
@@ -138,15 +157,39 @@ onUnmounted(() => {
       </div>
 
       <p v-if="todos.length === 0" class="empty-message">
-        タスクがありません。新しいタスクを追加してください。
+        タスクがありません。＋ボタンで追加してください。
       </p>
     </div>
 
-    <div class="todo-stats">
-      <p>合計: {{ todos.length }}件</p>
-      <p>完了: {{ todos.filter(t => t.completed).length }}件</p>
-      <p>未完了: {{ todos.filter(t => !t.completed).length }}件</p>
-    </div>
+    <!-- FAB（右下の丸ボタン） -->
+    <button class="fab" @click="openAddPanel" aria-label="タスクを追加">
+      <span class="fab-icon">＋</span>
+    </button>
+
+    <!-- オーバーレイ -->
+    <Transition name="fade">
+      <div v-if="showAddPanel" class="overlay" @click="closeAddPanel"></div>
+    </Transition>
+
+    <!-- 下からスライドするタスク追加パネル -->
+    <Transition name="slide-up">
+      <div v-if="showAddPanel" class="add-panel">
+        <div class="add-panel-handle"></div>
+        <h2 class="add-panel-title">タスクを追加</h2>
+        <input
+          v-model="newTodoText"
+          type="text"
+          class="add-panel-input"
+          placeholder="新しいタスクを入力..."
+          @keyup.enter="addTodo"
+          autofocus
+        />
+        <div class="add-panel-actions">
+          <button class="cancel-btn" @click="closeAddPanel">キャンセル</button>
+          <button class="add-btn" @click="addTodo" :disabled="newTodoText.trim() === ''">追加</button>
+        </div>
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -160,21 +203,32 @@ onUnmounted(() => {
 }
 
 .todo-app {
+  width: 100%;
   max-width: 600px;
   margin: 0 auto;
+  min-height: 100vh;
+  position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
+/* ヘッダー */
 .app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1em;
+  padding: 1em 1.2em;
+  background-color: #242424;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   flex-wrap: wrap;
   gap: 0.5em;
 }
 
 .app-header h1 {
-  font-size: 2.5em;
+  font-size: 1.6em;
   margin: 0;
 }
 
@@ -185,15 +239,15 @@ onUnmounted(() => {
 }
 
 .user-email {
-  font-size: 0.85em;
+  font-size: 0.8em;
   opacity: 0.6;
 }
 
 .logout-btn {
   background-color: transparent;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  padding: 0.4em 0.8em;
-  font-size: 0.85em;
+  padding: 0.35em 0.75em;
+  font-size: 0.8em;
   border-radius: 6px;
   cursor: pointer;
 }
@@ -202,18 +256,40 @@ onUnmounted(() => {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-.todo-input {
+/* 進捗セクション */
+.progress-section {
+  padding: 1em 1.2em 0.8em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.progress-labels {
   display: flex;
-  gap: 0.5em;
-  margin-bottom: 2em;
+  justify-content: space-between;
+  font-size: 0.85em;
+  opacity: 0.7;
+  margin-bottom: 0.5em;
 }
 
-.todo-input input {
-  flex: 1;
+.progress-bar-track {
+  width: 100%;
+  height: 6px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
 }
 
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #646cff, #a78bfa);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+/* タスクリスト */
 .todo-list {
-  margin-bottom: 2em;
+  flex: 1;
+  padding: 1em 1.2em;
+  padding-bottom: 5em;
 }
 
 .todo-item {
@@ -223,7 +299,7 @@ onUnmounted(() => {
   padding: 1em;
   margin-bottom: 0.5em;
   background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  border-radius: 10px;
   transition: background-color 0.2s;
 }
 
@@ -233,7 +309,7 @@ onUnmounted(() => {
 
 .todo-item.completed .todo-text {
   text-decoration: line-through;
-  opacity: 0.5;
+  opacity: 0.45;
 }
 
 .todo-text {
@@ -243,8 +319,9 @@ onUnmounted(() => {
 
 .delete-btn {
   background-color: #ff4444;
-  padding: 0.4em 0.8em;
-  font-size: 0.9em;
+  padding: 0.3em 0.7em;
+  font-size: 0.85em;
+  border-radius: 6px;
 }
 
 .delete-btn:hover {
@@ -252,24 +329,165 @@ onUnmounted(() => {
 }
 
 .empty-message {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.4);
   font-style: italic;
-  padding: 2em;
+  padding: 3em 1em;
+  text-align: center;
 }
 
-.todo-stats {
+/* FABボタン */
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #646cff, #a78bfa);
+  border: none;
+  box-shadow: 0 4px 16px rgba(100, 108, 255, 0.45);
   display: flex;
-  justify-content: space-around;
-  padding: 1em;
-  background-color: rgba(255, 255, 255, 0.05);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 20;
+  transition: transform 0.2s, box-shadow 0.2s;
+  padding: 0;
+}
+
+.fab:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 20px rgba(100, 108, 255, 0.6);
+  border-color: transparent;
+}
+
+.fab-icon {
+  font-size: 1.8em;
+  line-height: 1;
+  color: #fff;
+  font-weight: 300;
+}
+
+/* オーバーレイ */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 30;
+}
+
+/* タスク追加パネル */
+.add-panel {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #2e2e2e;
+  border-radius: 20px 20px 0 0;
+  padding: 1em 1.5em 2em;
+  z-index: 40;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+}
+
+.add-panel-handle {
+  width: 40px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 2px;
+  margin: 0 auto 1.2em;
+}
+
+.add-panel-title {
+  font-size: 1.1em;
+  margin: 0 0 1em;
+  text-align: left;
+}
+
+.add-panel-input {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 1em;
+  padding: 0.75em 1em;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background-color: rgba(255, 255, 255, 0.07);
+  color: inherit;
+  margin-bottom: 1em;
+}
+
+.add-panel-input:focus {
+  outline: none;
+  border-color: #646cff;
+}
+
+.add-panel-actions {
+  display: flex;
+  gap: 0.75em;
+  justify-content: flex-end;
+}
+
+.cancel-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.6em 1.2em;
   border-radius: 8px;
+  cursor: pointer;
 }
 
-.todo-stats p {
-  margin: 0;
+.cancel-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
+.add-btn {
+  background: linear-gradient(135deg, #646cff, #a78bfa);
+  border: none;
+  padding: 0.6em 1.5em;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.add-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.add-btn:not(:disabled):hover {
+  opacity: 0.9;
+  border-color: transparent;
+}
+
+/* スライドアップトランジション */
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.slide-up-enter-from,
+.slide-up-leave-to {
+  transform: translateY(100%);
+}
+
+/* フェードトランジション */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+/* ライトモード */
 @media (prefers-color-scheme: light) {
+  .app-header {
+    background-color: #ffffff;
+    border-bottom-color: rgba(0, 0, 0, 0.08);
+  }
+
   .logout-btn {
     border-color: rgba(0, 0, 0, 0.2);
   }
@@ -278,20 +496,47 @@ onUnmounted(() => {
     background-color: rgba(0, 0, 0, 0.05);
   }
 
+  .progress-section {
+    border-bottom-color: rgba(0, 0, 0, 0.06);
+  }
+
+  .progress-bar-track {
+    background-color: rgba(0, 0, 0, 0.08);
+  }
+
   .todo-item {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: rgba(0, 0, 0, 0.04);
   }
 
   .todo-item:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(0, 0, 0, 0.08);
   }
 
   .empty-message {
-    color: rgba(0, 0, 0, 0.5);
+    color: rgba(0, 0, 0, 0.4);
   }
 
-  .todo-stats {
-    background-color: rgba(0, 0, 0, 0.05);
+  .add-panel {
+    background-color: #f5f5f5;
+  }
+
+  .add-panel-input {
+    background-color: #ffffff;
+    border-color: rgba(0, 0, 0, 0.15);
+    color: #213547;
+  }
+
+  .cancel-btn {
+    border-color: rgba(0, 0, 0, 0.2);
+    color: #213547;
+  }
+
+  .cancel-btn:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+
+  .add-panel-handle {
+    background: rgba(0, 0, 0, 0.2);
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -119,23 +119,24 @@ onUnmounted(() => {
   <AuthForm v-else-if="!currentUser" />
 
   <div v-else class="todo-app">
-    <!-- 固定ヘッダー -->
-    <header class="app-header">
-      <h1>📝 Todoリスト</h1>
-      <div class="user-info">
-        <span class="user-email">{{ currentUser.email }}</span>
-        <button class="logout-btn" @click="logout">ログアウト</button>
-      </div>
-    </header>
+    <!-- ヘッダー＋進捗をまとめてスティッキー固定 -->
+    <div class="sticky-top">
+      <header class="app-header">
+        <h1>Todoリスト</h1>
+        <div class="user-info">
+          <span class="user-email">{{ currentUser.email }}</span>
+          <button class="logout-btn" @click="logout">ログアウト</button>
+        </div>
+      </header>
 
-    <!-- 進捗エリア -->
-    <div class="progress-section">
-      <div class="progress-labels">
-        <span>進捗 {{ progressPercent }}%</span>
-        <span>{{ completedCount }} / {{ todos.length }} 完了</span>
-      </div>
-      <div class="progress-bar-track">
-        <div class="progress-bar-fill" :style="{ width: progressPercent + '%' }"></div>
+      <div class="progress-section">
+        <div class="progress-labels">
+          <span>進捗 {{ progressPercent }}%</span>
+          <span>{{ completedCount }} / {{ todos.length }} 完了</span>
+        </div>
+        <div class="progress-bar-track">
+          <div class="progress-bar-fill" :style="{ width: progressPercent + '%' }"></div>
+        </div>
       </div>
     </div>
 
@@ -212,68 +213,84 @@ onUnmounted(() => {
   flex-direction: column;
 }
 
-/* ヘッダー */
-.app-header {
+/* スティッキーまとめコンテナ（ヘッダー＋進捗） */
+.sticky-top {
   position: sticky;
   top: 0;
   z-index: 10;
+  background-color: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+/* ヘッダー */
+.app-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1em 1.2em;
-  background-color: #242424;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  flex-wrap: wrap;
+  padding: 0.75em 1.2em;
   gap: 0.5em;
+  overflow: hidden;
 }
 
 .app-header h1 {
-  font-size: 1.6em;
+  font-size: 1.3em;
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
 }
 
 .user-info {
   display: flex;
   align-items: center;
-  gap: 0.8em;
+  gap: 0.6em;
+  flex-shrink: 0;
 }
 
 .user-email {
-  font-size: 0.8em;
-  opacity: 0.6;
+  font-size: 0.78em;
+  color: rgba(33, 53, 71, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
 }
 
 .logout-btn {
   background-color: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  padding: 0.35em 0.75em;
-  font-size: 0.8em;
+  border: 1px solid rgba(33, 53, 71, 0.2);
+  padding: 0.3em 0.65em;
+  font-size: 0.78em;
   border-radius: 6px;
   cursor: pointer;
+  color: #213547;
+  white-space: nowrap;
 }
 
 .logout-btn:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(33, 53, 71, 0.05);
+  border-color: rgba(33, 53, 71, 0.35);
 }
 
 /* 進捗セクション */
 .progress-section {
-  padding: 1em 1.2em 0.8em;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.6em 1.2em 0.8em;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 .progress-labels {
   display: flex;
   justify-content: space-between;
-  font-size: 0.85em;
-  opacity: 0.7;
-  margin-bottom: 0.5em;
+  font-size: 0.82em;
+  color: rgba(33, 53, 71, 0.6);
+  margin-bottom: 0.45em;
 }
 
 .progress-bar-track {
   width: 100%;
   height: 6px;
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(0, 0, 0, 0.08);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -296,15 +313,17 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 1em;
-  padding: 1em;
+  padding: 0.9em 1em;
   margin-bottom: 0.5em;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: #ffffff;
   border-radius: 10px;
-  transition: background-color 0.2s;
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  transition: background-color 0.15s, box-shadow 0.15s;
 }
 
 .todo-item:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: #f8f8ff;
+  box-shadow: 0 1px 6px rgba(100, 108, 255, 0.1);
 }
 
 .todo-item.completed .todo-text {
@@ -315,21 +334,25 @@ onUnmounted(() => {
 .todo-text {
   flex: 1;
   text-align: left;
+  color: #213547;
 }
 
 .delete-btn {
-  background-color: #ff4444;
-  padding: 0.3em 0.7em;
-  font-size: 0.85em;
+  background-color: #fee2e2;
+  color: #dc2626;
+  border: none;
+  padding: 0.3em 0.65em;
+  font-size: 0.82em;
   border-radius: 6px;
 }
 
 .delete-btn:hover {
-  background-color: #ff6666;
+  background-color: #fecaca;
+  border-color: transparent;
 }
 
 .empty-message {
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(33, 53, 71, 0.4);
   font-style: italic;
   padding: 3em 1em;
   text-align: center;
@@ -345,7 +368,7 @@ onUnmounted(() => {
   border-radius: 50%;
   background: linear-gradient(135deg, #646cff, #a78bfa);
   border: none;
-  box-shadow: 0 4px 16px rgba(100, 108, 255, 0.45);
+  box-shadow: 0 4px 16px rgba(100, 108, 255, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -357,7 +380,7 @@ onUnmounted(() => {
 
 .fab:hover {
   transform: scale(1.1);
-  box-shadow: 0 6px 20px rgba(100, 108, 255, 0.6);
+  box-shadow: 0 6px 20px rgba(100, 108, 255, 0.55);
   border-color: transparent;
 }
 
@@ -372,7 +395,7 @@ onUnmounted(() => {
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.35);
   z-index: 30;
 }
 
@@ -382,17 +405,17 @@ onUnmounted(() => {
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #2e2e2e;
+  background-color: #ffffff;
   border-radius: 20px 20px 0 0;
   padding: 1em 1.5em 2em;
   z-index: 40;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
 }
 
 .add-panel-handle {
   width: 40px;
   height: 4px;
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.15);
   border-radius: 2px;
   margin: 0 auto 1.2em;
 }
@@ -401,6 +424,7 @@ onUnmounted(() => {
   font-size: 1.1em;
   margin: 0 0 1em;
   text-align: left;
+  color: #213547;
 }
 
 .add-panel-input {
@@ -409,15 +433,16 @@ onUnmounted(() => {
   font-size: 1em;
   padding: 0.75em 1em;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background-color: rgba(255, 255, 255, 0.07);
-  color: inherit;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background-color: #f9f9f9;
+  color: #213547;
   margin-bottom: 1em;
 }
 
 .add-panel-input:focus {
   outline: none;
   border-color: #646cff;
+  background-color: #ffffff;
 }
 
 .add-panel-actions {
@@ -428,15 +453,16 @@ onUnmounted(() => {
 
 .cancel-btn {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(0, 0, 0, 0.18);
   padding: 0.6em 1.2em;
   border-radius: 8px;
   cursor: pointer;
+  color: #213547;
 }
 
 .cancel-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.3);
 }
 
 .add-btn {
@@ -455,7 +481,7 @@ onUnmounted(() => {
 }
 
 .add-btn:not(:disabled):hover {
-  opacity: 0.9;
+  opacity: 0.88;
   border-color: transparent;
 }
 
@@ -479,64 +505,5 @@ onUnmounted(() => {
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
-}
-
-/* ライトモード */
-@media (prefers-color-scheme: light) {
-  .app-header {
-    background-color: #ffffff;
-    border-bottom-color: rgba(0, 0, 0, 0.08);
-  }
-
-  .logout-btn {
-    border-color: rgba(0, 0, 0, 0.2);
-  }
-
-  .logout-btn:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
-
-  .progress-section {
-    border-bottom-color: rgba(0, 0, 0, 0.06);
-  }
-
-  .progress-bar-track {
-    background-color: rgba(0, 0, 0, 0.08);
-  }
-
-  .todo-item {
-    background-color: rgba(0, 0, 0, 0.04);
-  }
-
-  .todo-item:hover {
-    background-color: rgba(0, 0, 0, 0.08);
-  }
-
-  .empty-message {
-    color: rgba(0, 0, 0, 0.4);
-  }
-
-  .add-panel {
-    background-color: #f5f5f5;
-  }
-
-  .add-panel-input {
-    background-color: #ffffff;
-    border-color: rgba(0, 0, 0, 0.15);
-    color: #213547;
-  }
-
-  .cancel-btn {
-    border-color: rgba(0, 0, 0, 0.2);
-    color: #213547;
-  }
-
-  .cancel-btn:hover {
-    background: rgba(0, 0, 0, 0.05);
-  }
-
-  .add-panel-handle {
-    background: rgba(0, 0, 0, 0.2);
-  }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #f5f7fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -31,7 +31,8 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f0f0f0;
+  color: #213547;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -47,30 +48,16 @@ button:focus-visible {
 
 input[type="text"] {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid rgba(0, 0, 0, 0.15);
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #ffffff;
+  color: #213547;
   transition: border-color 0.25s;
 }
 
 input[type="text"]:focus {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  
-  button {
-    background-color: #f9f9f9;
-  }
-  
-  input[type="text"] {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -15,16 +15,12 @@
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100%;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary

- タイトルをスティッキーヘッダーに移動し、ユーザー情報・ログアウトボタンと横並びに配置
- ヘッダー直下に進捗バー（完了率 %・件数）を表示
- タスク追加の入力欄を削除し、右下に丸いFAB（Floating Action Button）を配置
- FAB押下で下からスライドするボトムシート（タスク追加パネル）が表示され、背景にはオーバーレイを表示

## Test plan

- [ ] ヘッダーにタイトルが表示されること
- [ ] ヘッダーにメールアドレスとログアウトボタンが表示されること
- [ ] ヘッダー下に進捗バーと完了率が表示されること
- [ ] タスク完了時に進捗バーが更新されること
- [ ] 右下の丸ボタン（＋）が表示されること
- [ ] 丸ボタン押下でタスク追加パネルが下からスライドして表示されること
- [ ] 背景のオーバーレイをタップするとパネルが閉じること
- [ ] タスクを追加するとパネルが閉じること

https://claude.ai/code/session_01LuTBeZUiaLk3GiPqP7AXGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuTBeZUiaLk3GiPqP7AXGv)_