### PR TITLE
feat: PWAバッヂに未完了タスク数を反映

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth'
 import {
   collection,
@@ -30,9 +30,22 @@ const showAddPanel = ref(false)
 let unsubscribeTodos: (() => void) | null = null
 
 const completedCount = computed(() => todos.value.filter(t => t.completed).length)
+const incompleteCount = computed(() => todos.value.filter(t => !t.completed).length)
 const progressPercent = computed(() =>
   todos.value.length === 0 ? 0 : Math.round((completedCount.value / todos.value.length) * 100)
 )
+
+const updateBadge = (count: number) => {
+  if ('setAppBadge' in navigator) {
+    if (count > 0) {
+      navigator.setAppBadge(count)
+    } else {
+      navigator.clearAppBadge()
+    }
+  }
+}
+
+watch(incompleteCount, updateBadge)
 
 const subscribeTodos = (uid: string) => {
   const todosRef = collection(db, 'users', uid, 'todos')
@@ -108,6 +121,7 @@ onMounted(() => {
 onUnmounted(() => {
   unsubscribeAuth?.()
   unsubscribeTodos?.()
+  if ('clearAppBadge' in navigator) navigator.clearAppBadge()
 })
 </script>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Web Badging API (`navigator.setAppBadge`) を使用し、未完了タスク数をPWAアイコンのバッヂに表示
- タスクがすべて完了した場合、またはアプリ終了時にバッヂをクリア (`navigator.clearAppBadge`)
- APIが未対応のブラウザでは何もしない（feature detection 済み）

## 動作

- PWA としてインストール済みの状態でタスクを追加／完了するとアイコンのバッヂ数が変わる
- 対応ブラウザ: Chrome/Edge (デスクトップ・Android)

## Test plan

- [ ] PWA としてインストールしてタスクを追加 → アイコンにバッヂ数が表示される
- [ ] タスクを完了にする → バッヂ数が減る
- [ ] 全タスクを完了にする → バッヂが消える
- [ ] ログアウト → バッヂが消える
- [ ] 非対応ブラウザ (Safari 等) でエラーが出ないこと

https://claude.ai/code/session_01EcZeysTWV59LkHs3XUHJQd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcZeysTWV59LkHs3XUHJQd)_