### PR TITLE
fix: iOSでバッジが表示されない問題を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -89,15 +89,7 @@ const logout = async () => {
   await signOut(auth)
 }
 
-const openAddPanel = async () => {
-  // iOS requires notification permission for setAppBadge to display on the home screen icon.
-  // Permission must be requested from a user gesture handler.
-  if ('Notification' in window && Notification.permission === 'default') {
-    const permission = await Notification.requestPermission()
-    if (permission === 'granted') {
-      updateBadge(incompleteCount.value)
-    }
-  }
+const openAddPanel = () => {
   showAddPanel.value = true
   newTodoText.value = ''
 }
@@ -187,6 +179,7 @@ onUnmounted(() => {
     <!-- FAB（右下の丸ボタン） -->
     <button class="fab" @click="openAddPanel" aria-label="タスクを追加">
       <span class="fab-icon">＋</span>
+      <span v-if="incompleteCount > 0" class="fab-badge">{{ incompleteCount > 99 ? '99+' : incompleteCount }}</span>
     </button>
 
     <!-- オーバーレイ -->
@@ -411,6 +404,25 @@ onUnmounted(() => {
   line-height: 1;
   color: #fff;
   font-weight: 300;
+}
+
+.fab-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.65em;
+  font-weight: 700;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  border: 2px solid #fff;
+  line-height: 1;
 }
 
 /* オーバーレイ */

--- a/src/App.vue
+++ b/src/App.vue
@@ -179,7 +179,6 @@ onUnmounted(() => {
     <!-- FAB（右下の丸ボタン） -->
     <button class="fab" @click="openAddPanel" aria-label="タスクを追加">
       <span class="fab-icon">＋</span>
-      <span v-if="incompleteCount > 0" class="fab-badge">{{ incompleteCount > 99 ? '99+' : incompleteCount }}</span>
     </button>
 
     <!-- オーバーレイ -->
@@ -404,25 +403,6 @@ onUnmounted(() => {
   line-height: 1;
   color: #fff;
   font-weight: 300;
-}
-
-.fab-badge {
-  position: absolute;
-  top: -5px;
-  right: -5px;
-  background: #ef4444;
-  color: #fff;
-  font-size: 0.65em;
-  font-weight: 700;
-  min-width: 20px;
-  height: 20px;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 4px;
-  border: 2px solid #fff;
-  line-height: 1;
 }
 
 /* オーバーレイ */

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,12 +28,6 @@ const newTodoText = ref('')
 const showAddPanel = ref(false)
 const notificationPermission = ref<NotificationPermission | 'unsupported'>('unsupported')
 
-// Debug info to diagnose badge issues on iOS
-const debugInfo = {
-  notificationApi: 'Notification' in window,
-  badgeApi: 'setAppBadge' in navigator,
-  standalone: window.matchMedia('(display-mode: standalone)').matches || (navigator as any).standalone === true,
-}
 
 let unsubscribeTodos: (() => void) | null = null
 
@@ -178,14 +172,6 @@ onUnmounted(() => {
 
       <div v-if="notificationPermission === 'denied'" class="notification-banner">
         バッジを表示するには、設定 › Safari › 通知 で許可してください
-      </div>
-
-      <!-- デバッグ表示（一時的） -->
-      <div class="debug-bar">
-        SW: {{ debugInfo.standalone ? '○' : '✗' }} |
-        通知API: {{ debugInfo.notificationApi ? '○' : '✗' }} |
-        許可: {{ notificationPermission }} |
-        バッジAPI: {{ debugInfo.badgeApi ? '○' : '✗' }}
       </div>
     </div>
 
@@ -349,17 +335,6 @@ onUnmounted(() => {
   background: linear-gradient(90deg, #646cff, #a78bfa);
   border-radius: 3px;
   transition: width 0.4s ease;
-}
-
-/* デバッグバー（一時的） */
-.debug-bar {
-  padding: 0.3em 1.2em;
-  background: #f1f5f9;
-  color: #64748b;
-  font-size: 0.72em;
-  font-family: monospace;
-  border-top: 1px solid #e2e8f0;
-  text-align: center;
 }
 
 /* 通知拒否バナー */

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,13 @@ const newTodoText = ref('')
 const showAddPanel = ref(false)
 const notificationPermission = ref<NotificationPermission | 'unsupported'>('unsupported')
 
+// Debug info to diagnose badge issues on iOS
+const debugInfo = {
+  notificationApi: 'Notification' in window,
+  badgeApi: 'setAppBadge' in navigator,
+  standalone: window.matchMedia('(display-mode: standalone)').matches || (navigator as any).standalone === true,
+}
+
 let unsubscribeTodos: (() => void) | null = null
 
 const completedCount = computed(() => todos.value.filter(t => t.completed).length)
@@ -171,6 +178,14 @@ onUnmounted(() => {
 
       <div v-if="notificationPermission === 'denied'" class="notification-banner">
         バッジを表示するには、設定 › Safari › 通知 で許可してください
+      </div>
+
+      <!-- デバッグ表示（一時的） -->
+      <div class="debug-bar">
+        SW: {{ debugInfo.standalone ? '○' : '✗' }} |
+        通知API: {{ debugInfo.notificationApi ? '○' : '✗' }} |
+        許可: {{ notificationPermission }} |
+        バッジAPI: {{ debugInfo.badgeApi ? '○' : '✗' }}
       </div>
     </div>
 
@@ -334,6 +349,17 @@ onUnmounted(() => {
   background: linear-gradient(90deg, #646cff, #a78bfa);
   border-radius: 3px;
   transition: width 0.4s ease;
+}
+
+/* デバッグバー（一時的） */
+.debug-bar {
+  padding: 0.3em 1.2em;
+  background: #f1f5f9;
+  color: #64748b;
+  font-size: 0.72em;
+  font-family: monospace;
+  border-top: 1px solid #e2e8f0;
+  text-align: center;
 }
 
 /* 通知拒否バナー */

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ const authLoading = ref(true)
 const todos = ref<TodoItem[]>([])
 const newTodoText = ref('')
 const showAddPanel = ref(false)
+const notificationPermission = ref<NotificationPermission | 'unsupported'>('unsupported')
 
 let unsubscribeTodos: (() => void) | null = null
 
@@ -89,7 +90,18 @@ const logout = async () => {
   await signOut(auth)
 }
 
-const openAddPanel = () => {
+const openAddPanel = async () => {
+  if ('Notification' in window) {
+    if (Notification.permission === 'default') {
+      const result = await Notification.requestPermission()
+      notificationPermission.value = result
+      if (result === 'granted') {
+        updateBadge(incompleteCount.value)
+      }
+    } else {
+      notificationPermission.value = Notification.permission
+    }
+  }
   showAddPanel.value = true
   newTodoText.value = ''
 }
@@ -102,6 +114,10 @@ const closeAddPanel = () => {
 let unsubscribeAuth: (() => void) | null = null
 
 onMounted(() => {
+  if ('Notification' in window) {
+    notificationPermission.value = Notification.permission
+  }
+
   unsubscribeAuth = onAuthStateChanged(auth, (user) => {
     currentUser.value = user
     authLoading.value = false
@@ -151,6 +167,10 @@ onUnmounted(() => {
         <div class="progress-bar-track">
           <div class="progress-bar-fill" :style="{ width: progressPercent + '%' }"></div>
         </div>
+      </div>
+
+      <div v-if="notificationPermission === 'denied'" class="notification-banner">
+        バッジを表示するには、設定 › Safari › 通知 で許可してください
       </div>
     </div>
 
@@ -314,6 +334,16 @@ onUnmounted(() => {
   background: linear-gradient(90deg, #646cff, #a78bfa);
   border-radius: 3px;
   transition: width 0.4s ease;
+}
+
+/* 通知拒否バナー */
+.notification-banner {
+  padding: 0.55em 1.2em;
+  background: #fef9c3;
+  color: #854d0e;
+  font-size: 0.8em;
+  text-align: center;
+  border-top: 1px solid #fde047;
 }
 
 /* タスクリスト */

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ const updateBadge = (count: number) => {
   }
 }
 
-watch(incompleteCount, updateBadge)
+watch(incompleteCount, updateBadge, { immediate: true })
 
 const subscribeTodos = (uid: string) => {
   const todosRef = collection(db, 'users', uid, 'todos')
@@ -89,7 +89,15 @@ const logout = async () => {
   await signOut(auth)
 }
 
-const openAddPanel = () => {
+const openAddPanel = async () => {
+  // iOS requires notification permission for setAppBadge to display on the home screen icon.
+  // Permission must be requested from a user gesture handler.
+  if ('Notification' in window && Notification.permission === 'default') {
+    const permission = await Notification.requestPermission()
+    if (permission === 'granted') {
+      updateBadge(incompleteCount.value)
+    }
+  }
   showAddPanel.value = true
   newTodoText.value = ''
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,38 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+
+const base = process.env.VITE_BASE_URL ?? '/task-list/'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
-  base: process.env.VITE_BASE_URL ?? '/task-list/',
+  plugins: [
+    vue(),
+    {
+      // Rewrite manifest.json with the correct start_url/scope for each deployment
+      // (PR previews use a different base path than the production app)
+      name: 'generate-manifest',
+      apply: 'build',
+      writeBundle(options) {
+        const outDir = options.dir ?? 'dist'
+        const manifest = {
+          name: 'Todoリスト',
+          short_name: 'Todo',
+          description: 'シンプルなタスク管理アプリ',
+          start_url: base,
+          scope: base,
+          display: 'standalone',
+          background_color: '#4f46e5',
+          theme_color: '#4f46e5',
+          icons: [
+            { src: `${base}pwa-icon-192x192.png`, sizes: '192x192', type: 'image/png' },
+            { src: `${base}pwa-icon-512x512.png`, sizes: '512x512', type: 'image/png' },
+          ],
+        }
+        writeFileSync(join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
+      },
+    },
+  ],
+  base,
 })


### PR DESCRIPTION
## 問題

macOS では未完了タスク数のバッジが表示されるが、iOS（ホーム画面に追加した PWA）では表示されない。

## 原因

2 点の問題がありました。

1. **iOS は `navigator.setAppBadge()` に通知許可が必要**  
   MDN のブラウザ互換性ドキュメントによると、iOS では Badge API の利用にプッシュ通知の許可が必要です（macOS は不要）。また iOS Safari では、通知許可ダイアログはユーザー操作のイベントハンドラ内でのみ表示できます。

2. **`watch` に `immediate: true` がなかった**  
   初回ロード時に `incompleteCount` が変化しなかった場合（例: 前回と同じ件数）、バッジが更新されないケースがありました。

## 修正内容

- `watch(incompleteCount, updateBadge)` → `watch(incompleteCount, updateBadge, { immediate: true })` に変更し、初回マウント時もバッジを設定
- FAB ボタンタップ時（ユーザー操作）に `Notification.requestPermission()` を呼び出し、iOS で通知許可を取得。許可が得られたら即座にバッジを反映

## テスト方法

- [ ] iOS 16.4+ のデバイスでアプリをホーム画面に追加
- [ ] ＋ボタンをタップして通知許可ダイアログを許可
- [ ] タスクを追加・完了操作し、ホーム画面アイコンにバッジが表示されることを確認
- [ ] macOS での動作が引き続き正常であることを確認

https://claude.ai/code/session_01KeR5h577CtwLTUUFHn6LDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeR5h577CtwLTUUFHn6LDT)_