### PR TITLE
ログイン直後に通知許可ダイアログを表示する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -91,18 +91,20 @@ const logout = async () => {
   await signOut(auth)
 }
 
-const openAddPanel = async () => {
-  if ('Notification' in window) {
-    if (Notification.permission === 'default') {
-      const result = await Notification.requestPermission()
-      notificationPermission.value = result
-      if (result === 'granted') {
-        updateBadge(incompleteCount.value)
-      }
-    } else {
-      notificationPermission.value = Notification.permission
+const requestNotificationPermission = async () => {
+  if (!('Notification' in window)) return
+  if (Notification.permission === 'default') {
+    const result = await Notification.requestPermission()
+    notificationPermission.value = result
+    if (result === 'granted') {
+      updateBadge(incompleteCount.value)
     }
+  } else {
+    notificationPermission.value = Notification.permission
   }
+}
+
+const openAddPanel = () => {
   showAddPanel.value = true
   newTodoText.value = ''
 }
@@ -118,7 +120,6 @@ onMounted(() => {
   if ('Notification' in window) {
     notificationPermission.value = Notification.permission
   }
-
   unsubscribeAuth = onAuthStateChanged(auth, (user) => {
     currentUser.value = user
     authLoading.value = false
@@ -131,6 +132,7 @@ onMounted(() => {
 
     if (user) {
       subscribeTodos(user.uid)
+      requestNotificationPermission()
     }
   })
 })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 通知許可リクエスト (`Notification.requestPermission()`) を `openAddPanel()` から切り出し、`requestNotificationPermission()` として独立した関数にまとめた
- `onAuthStateChanged` でユーザーのログインを検知した直後に `requestNotificationPermission()` を呼ぶよう変更し、FABボタンを押すことなくログイン直後に通知許可ダイアログが表示されるようにした

## Test plan

- [ ] メールアドレス・パスワードでログインし、ログイン直後に通知許可ダイアログが表示されることを確認
- [ ] 許可した場合、`notificationPermission` が `'granted'` になりバッジが更新されることを確認
- [ ] 拒否した場合、`'denied'` バナーが表示されることを確認
- [ ] 許可済みの状態でログインした場合、ダイアログが再表示されないことを確認

https://claude.ai/code/session_012remGaJNDthtfHxn4mzd7w
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012remGaJNDthtfHxn4mzd7w)_