### PR TITLE
PRプレビューURLから pr-preview ディレクトリを削除

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,9 +34,10 @@ jobs:
         if: github.event.action != 'closed'
         run: npm run build
         env:
-          VITE_BASE_URL: /task-list/pr-preview/pr-${{ github.event.pull_request.number }}/
+          VITE_BASE_URL: /task-list/pr-${{ github.event.pull_request.number }}/
 
       - name: PRプレビューのデプロイ・削除
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: dist
+          umbrella-dir: '.'


### PR DESCRIPTION
## 変更内容

- `VITE_BASE_URL` から `/pr-preview` パスを削除
- `pr-preview-action` に `umbrella-dir: '.'` を追加し、デプロイ先ディレクトリを変更

## 変更前後のURL

| | URL |
|---|---|
| 変更前 | `https://keigo-hisazumi.github.io/task-list/pr-preview/pr-{number}/` |
| 変更後 | `https://keigo-hisazumi.github.io/task-list/pr-{number}/` |

---
_Generated by [Claude Code](https://claude.ai/code/session_017wA49GJqkporJHyZCQEF52)_