### PR TITLE
スタイルのグラデーションを廃止

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -545,7 +545,7 @@ onUnmounted(() => {
 
 .progress-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, #646cff, #a78bfa);
+  background: #646cff;
   border-radius: 3px;
   transition: width 0.4s ease;
 }
@@ -634,7 +634,7 @@ onUnmounted(() => {
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #646cff, #a78bfa);
+  background: #646cff;
   border: none;
   box-shadow: 0 4px 16px rgba(100, 108, 255, 0.4);
   display: flex;
@@ -744,7 +744,7 @@ onUnmounted(() => {
 }
 
 .add-btn {
-  background: linear-gradient(135deg, #646cff, #a78bfa);
+  background: #646cff;
   border: none;
   padding: 0.6em 1.5em;
   border-radius: 8px;


### PR DESCRIPTION
## Summary

- 進捗バー・FABボタン・追加ボタンの `linear-gradient` を廃止
- すべて単色 `#646cff` に統一

## 変更箇所

- `.progress-bar-fill`: `linear-gradient(90deg, #646cff, #a78bfa)` → `#646cff`
- `.fab`: `linear-gradient(135deg, #646cff, #a78bfa)` → `#646cff`
- `.add-btn`: `linear-gradient(135deg, #646cff, #a78bfa)` → `#646cff`

https://claude.ai/code/session_01AtyorNoU8SzGkx8r4x16h3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtyorNoU8SzGkx8r4x16h3)_