### PR TITLE
fix: タスク追加・編集モーダルの開閉アニメーションを修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -160,13 +160,13 @@ const subscribeTodos = (uid: string) => {
 
 const addTodo = async () => {
   if (!currentUser.value || newTodoText.value.trim() === '') return
+  const text = newTodoText.value.trim()
+  closeAddPanel()
   await addDoc(collection(db, 'users', currentUser.value.uid, 'todos'), {
-    text: newTodoText.value.trim(),
+    text,
     completed: false,
     createdAt: serverTimestamp(),
   })
-  newTodoText.value = ''
-  showAddPanel.value = false
 }
 
 const deleteTodo = async (id: string) => {
@@ -193,16 +193,17 @@ const closeEditPanel = () => {
 
 const updateTodo = async () => {
   if (!currentUser.value || !editingTodo.value || editTodoText.value.trim() === '') return
-  await updateDoc(doc(db, 'users', currentUser.value.uid, 'todos', editingTodo.value.id), {
-    text: editTodoText.value.trim(),
-  })
+  const id = editingTodo.value.id
+  const text = editTodoText.value.trim()
   closeEditPanel()
+  await updateDoc(doc(db, 'users', currentUser.value.uid, 'todos', id), { text })
 }
 
 const deleteTodoAndClose = async () => {
   if (!currentUser.value || !editingTodo.value) return
-  await deleteTodo(editingTodo.value.id)
+  const id = editingTodo.value.id
   closeEditPanel()
+  await deleteTodo(id)
 }
 
 const deleteCompletedTodos = async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -38,12 +38,15 @@ let dragStartY = 0
 
 const addPanelStyle = computed(() => {
   if (isSwipeClosing.value) {
-    return { transform: 'translateY(100%)', transition: 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)' }
+    return { transform: 'translateY(100%)' }
   }
   if (isDragging.value) {
     return { transform: `translateY(${panelTranslateY.value}px)`, transition: 'none' }
   }
-  return { transform: `translateY(${panelTranslateY.value}px)`, transition: 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)' }
+  if (panelTranslateY.value > 0) {
+    return { transform: `translateY(${panelTranslateY.value}px)` }
+  }
+  return {}
 })
 
 const onPanelTouchStart = (e: TouchEvent) => {
@@ -84,12 +87,15 @@ let editDragStartY = 0
 
 const editPanelStyle = computed(() => {
   if (isEditSwipeClosing.value) {
-    return { transform: 'translateY(100%)', transition: 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)' }
+    return { transform: 'translateY(100%)' }
   }
   if (isEditDragging.value) {
     return { transform: `translateY(${editPanelTranslateY.value}px)`, transition: 'none' }
   }
-  return { transform: `translateY(${editPanelTranslateY.value}px)`, transition: 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)' }
+  if (editPanelTranslateY.value > 0) {
+    return { transform: `translateY(${editPanelTranslateY.value}px)` }
+  }
+  return {}
 })
 
 const onEditPanelTouchStart = (e: TouchEvent) => {
@@ -352,7 +358,7 @@ onUnmounted(() => {
     <!-- オーバーレイ -->
     <Transition name="fade">
       <div
-        v-if="showAddPanel || showEditPanel"
+        v-if="(showAddPanel || showEditPanel) && !isSwipeClosing && !isEditSwipeClosing"
         class="overlay"
         @click="showAddPanel ? closeAddPanel() : closeEditPanel()"
       ></div>
@@ -678,6 +684,7 @@ onUnmounted(() => {
   padding: 1em 1.5em 2em;
   z-index: 40;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
+  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .add-panel-handle {
@@ -777,7 +784,7 @@ onUnmounted(() => {
 /* フェードトランジション */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.25s ease;
+  transition: opacity 0.3s ease;
 }
 
 .fade-enter-from,


### PR DESCRIPTION
## Summary

- **開く時**: インラインスタイル `translateY(0px)` が Vue の `slide-up-enter-from` クラスを上書きしていたバグを修正。通常状態では inline style を返さない (`{}`) ようにし、`.add-panel` の CSS に `transition` を追加することで、下からのスライドアップが正しく動作するようにした
- **ボタンで閉じる時**: オーバーレイの fade 時間を 0.25s → 0.3s に統一し、パネルのスライドダウンと完全に同時に完了するようにした
- **スワイプで閉じる時**: `isSwipeClosing` / `isEditSwipeClosing` が `true` になった瞬間にオーバーレイの `v-if` が `false` になるよう条件を変更し、パネルのスライドダウンとグレーアウトのフェードアウトが同時に始まるようにした

## Test plan

- [ ] ＋ボタンを押してパネルが下からスライドアップして表示されることを確認
- [ ] ✕ボタンを押してパネルが下にスライドダウンしながらグレーアウトも同時に消えることを確認
- [ ] オーバーレイタップで閉じる場合も同様に同時に消えることを確認
- [ ] スワイプで下に引っ張って閉じた際にグレーアウトがパネルと同時にフェードアウトすることを確認
- [ ] スワイプ途中で離した場合（閾値以下）にパネルが元の位置に戻ることを確認
- [ ] 編集パネルでも同様の動作を確認

https://claude.ai/code/session_01F4pgY58uWeitsRxB3V2ud3

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4pgY58uWeitsRxB3V2ud3)_