### PR TITLE
ローディング画面にスピナーアニメーションを導入

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -288,7 +288,7 @@ onUnmounted(() => {
 
 <template>
   <div v-if="authLoading" class="loading-screen">
-    <p>読み込み中...</p>
+    <div class="loading-spinner"></div>
   </div>
 
   <AuthForm v-else-if="!currentUser" />
@@ -432,7 +432,19 @@ onUnmounted(() => {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  opacity: 0.6;
+}
+
+.loading-spinner {
+  width: 44px;
+  height: 44px;
+  border: 4px solid rgba(102, 126, 234, 0.2);
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 .todo-app {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 認証状態の読み込み中に表示していたテキスト「読み込み中...」をCSSアニメーションのローディングサークルに置き換え
- アプリのアクセントカラー（`#667eea`）に合わせたスピナーデザイン
- 既存の外部ライブラリを使わず、純粋なCSS `@keyframes` で実装

## Test plan

- [ ] アプリを開いた直後にスピナーが表示されることを確認
- [ ] 認証完了後にスピナーが消えてメイン画面またはログイン画面に遷移することを確認

https://claude.ai/code/session_01NPsvc3xsWH997Mqrs7t5PL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPsvc3xsWH997Mqrs7t5PL)_