### PR TITLE
ハンバーガーメニューにアカウント名とログアウトを収める

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -328,7 +328,6 @@ onUnmounted(() => {
           <Transition name="menu-fade">
             <div v-if="showMenu" class="menu-dropdown">
               <div class="menu-account">
-                <span class="menu-account-label">アカウント</span>
                 <span class="menu-account-email">{{ currentUser.email }}</span>
               </div>
               <div class="menu-divider"></div>
@@ -567,22 +566,16 @@ onUnmounted(() => {
 
 .menu-account {
   padding: 0.9em 1em;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2em;
-}
-
-.menu-account-label {
-  font-size: 0.72em;
-  color: rgba(33, 53, 71, 0.45);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
 .menu-account-email {
+  display: block;
   font-size: 0.88em;
   color: #213547;
   word-break: break-all;
+  text-align: left;
+  pointer-events: none;
+  user-select: text;
 }
 
 .menu-divider {

--- a/src/App.vue
+++ b/src/App.vue
@@ -508,7 +508,6 @@ onUnmounted(() => {
   align-items: center;
   padding: 0.75em 1.2em;
   gap: 0.5em;
-  overflow: hidden;
 }
 
 .app-header h1 {

--- a/src/App.vue
+++ b/src/App.vue
@@ -230,6 +230,7 @@ const logout = async () => {
 }
 
 const showMenu = ref(false)
+const menuRef = ref<HTMLElement | null>(null)
 
 const toggleMenu = () => {
   showMenu.value = !showMenu.value
@@ -237,6 +238,12 @@ const toggleMenu = () => {
 
 const closeMenu = () => {
   showMenu.value = false
+}
+
+const handleDocumentClick = (e: MouseEvent) => {
+  if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
+    closeMenu()
+  }
 }
 
 
@@ -271,6 +278,7 @@ const closeAddPanel = () => {
 let unsubscribeAuth: (() => void) | null = null
 
 onMounted(() => {
+  document.addEventListener('click', handleDocumentClick)
   if ('Notification' in window) {
     notificationPermission.value = Notification.permission
   }
@@ -292,6 +300,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  document.removeEventListener('click', handleDocumentClick)
   unsubscribeAuth?.()
   unsubscribeTodos?.()
   if ('clearAppBadge' in navigator) navigator.clearAppBadge()
@@ -310,7 +319,7 @@ onUnmounted(() => {
     <div class="sticky-top">
       <header class="app-header">
         <h1>Todoリスト</h1>
-        <div class="hamburger-menu">
+        <div class="hamburger-menu" ref="menuRef">
           <button class="hamburger-btn" @click="toggleMenu" aria-label="メニューを開く" :aria-expanded="showMenu">
             <span class="hamburger-line"></span>
             <span class="hamburger-line"></span>
@@ -390,8 +399,6 @@ onUnmounted(() => {
       ></div>
     </Transition>
 
-    <!-- メニューオーバーレイ（タップで閉じる） -->
-    <div v-if="showMenu" class="menu-overlay" @click="closeMenu"></div>
 
     <!-- 下からスライドするタスク追加パネル -->
     <Transition :name="isSwipeClosing ? '' : 'slide-up'">
@@ -601,11 +608,6 @@ onUnmounted(() => {
   border-color: transparent;
 }
 
-.menu-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 45;
-}
 
 .menu-fade-enter-active,
 .menu-fade-leave-active {

--- a/src/App.vue
+++ b/src/App.vue
@@ -331,7 +331,14 @@ onUnmounted(() => {
                 <span class="menu-account-email">{{ currentUser.email }}</span>
               </div>
               <div class="menu-divider"></div>
-              <button class="menu-logout-btn" @click="logout">ログアウト</button>
+              <button class="menu-logout-btn" @click="logout">
+                <svg class="menu-logout-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+                  <polyline points="16 17 21 12 16 7"/>
+                  <line x1="21" y1="12" x2="9" y2="12"/>
+                </svg>
+                ログアウト
+              </button>
             </div>
           </Transition>
         </div>
@@ -586,6 +593,9 @@ onUnmounted(() => {
 
 .menu-logout-btn {
   width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
   text-align: left;
   background: none;
   border: none;
@@ -600,6 +610,11 @@ onUnmounted(() => {
   border-color: transparent;
 }
 
+.menu-logout-icon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
 
 .menu-fade-enter-active,
 .menu-fade-leave-active {

--- a/src/App.vue
+++ b/src/App.vue
@@ -225,8 +225,20 @@ const toggleTodo = async (id: string) => {
 }
 
 const logout = async () => {
+  showMenu.value = false
   await signOut(auth)
 }
+
+const showMenu = ref(false)
+
+const toggleMenu = () => {
+  showMenu.value = !showMenu.value
+}
+
+const closeMenu = () => {
+  showMenu.value = false
+}
+
 
 const requestNotificationPermission = async () => {
   if (!('Notification' in window)) return
@@ -298,9 +310,22 @@ onUnmounted(() => {
     <div class="sticky-top">
       <header class="app-header">
         <h1>Todoリスト</h1>
-        <div class="user-info">
-          <span class="user-email">{{ currentUser.email }}</span>
-          <button class="logout-btn" @click="logout">ログアウト</button>
+        <div class="hamburger-menu">
+          <button class="hamburger-btn" @click="toggleMenu" aria-label="メニューを開く" :aria-expanded="showMenu">
+            <span class="hamburger-line"></span>
+            <span class="hamburger-line"></span>
+            <span class="hamburger-line"></span>
+          </button>
+          <Transition name="menu-fade">
+            <div v-if="showMenu" class="menu-dropdown">
+              <div class="menu-account">
+                <span class="menu-account-label">アカウント</span>
+                <span class="menu-account-email">{{ currentUser.email }}</span>
+              </div>
+              <div class="menu-divider"></div>
+              <button class="menu-logout-btn" @click="logout">ログアウト</button>
+            </div>
+          </Transition>
         </div>
       </header>
 
@@ -364,6 +389,9 @@ onUnmounted(() => {
         @click="showAddPanel ? closeAddPanel() : closeEditPanel()"
       ></div>
     </Transition>
+
+    <!-- メニューオーバーレイ（タップで閉じる） -->
+    <div v-if="showMenu" class="menu-overlay" @click="closeMenu"></div>
 
     <!-- 下からスライドするタスク追加パネル -->
     <Transition :name="isSwipeClosing ? '' : 'slide-up'">
@@ -485,36 +513,109 @@ onUnmounted(() => {
   flex-shrink: 1;
 }
 
-.user-info {
-  display: flex;
-  align-items: center;
-  gap: 0.6em;
+.hamburger-menu {
+  position: relative;
   flex-shrink: 0;
 }
 
-.user-email {
-  font-size: 0.78em;
-  color: rgba(33, 53, 71, 0.55);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 160px;
-}
-
-.logout-btn {
-  background-color: transparent;
-  border: 1px solid rgba(33, 53, 71, 0.2);
-  padding: 0.3em 0.65em;
-  font-size: 0.78em;
-  border-radius: 6px;
+.hamburger-btn {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  background: none;
+  border: none;
   cursor: pointer;
-  color: #213547;
-  white-space: nowrap;
+  padding: 0.4em;
+  border-radius: 8px;
 }
 
-.logout-btn:hover {
-  background-color: rgba(33, 53, 71, 0.05);
-  border-color: rgba(33, 53, 71, 0.35);
+.hamburger-btn:hover {
+  background-color: rgba(33, 53, 71, 0.06);
+  border-color: transparent;
+}
+
+.hamburger-line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background-color: #213547;
+  border-radius: 2px;
+}
+
+.menu-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  min-width: 220px;
+  z-index: 50;
+  overflow: hidden;
+}
+
+.menu-account {
+  padding: 0.9em 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+.menu-account-label {
+  font-size: 0.72em;
+  color: rgba(33, 53, 71, 0.45);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.menu-account-email {
+  font-size: 0.88em;
+  color: #213547;
+  word-break: break-all;
+}
+
+.menu-divider {
+  height: 1px;
+  background: rgba(0, 0, 0, 0.08);
+  margin: 0;
+}
+
+.menu-logout-btn {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.85em 1em;
+  font-size: 0.9em;
+  color: #dc2626;
+  cursor: pointer;
+}
+
+.menu-logout-btn:hover {
+  background-color: #fee2e2;
+  border-color: transparent;
+}
+
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 45;
+}
+
+.menu-fade-enter-active,
+.menu-fade-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.menu-fade-enter-from,
+.menu-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
 }
 
 /* 進捗セクション */


### PR DESCRIPTION
## Summary

- ヘッダーに表示していたメールアドレスとログアウトボタンを削除
- 代わりにハンバーガーアイコンボタン（三本線）を右上に配置
- タップするとドロップダウンメニューが表示され、アカウントのメールアドレスとログアウトボタンを確認できる
- メニュー外（背景）タップで閉じる

## Test plan

- [ ] ログイン後、ヘッダー右上のハンバーガーアイコンをタップしてメニューが表示されることを確認
- [ ] メニューにアカウントのメールアドレスが表示されることを確認
- [ ] 「ログアウト」ボタンをタップしてログアウトできることを確認
- [ ] メニュー外をタップしてメニューが閉じることを確認

https://claude.ai/code/session_011DJ4o7YfG88arr6wfYbch3

---
_Generated by [Claude Code](https://claude.ai/code/session_011DJ4o7YfG88arr6wfYbch3)_