### PR TITLE
起動時のタスク空表示ラグを解消：localStorage キャッシュを導入

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,6 +24,24 @@ interface TodoItem {
 const currentUser = ref<User | null>(null)
 const authLoading = ref(true)
 const todos = ref<TodoItem[]>([])
+const todosLoading = ref(false)
+
+const TODOS_CACHE_KEY = (uid: string) => `todos_cache_${uid}`
+
+const loadCachedTodos = (uid: string): TodoItem[] => {
+  try {
+    const raw = localStorage.getItem(TODOS_CACHE_KEY(uid))
+    return raw ? (JSON.parse(raw) as TodoItem[]) : []
+  } catch {
+    return []
+  }
+}
+
+const saveCachedTodos = (uid: string, items: TodoItem[]) => {
+  try {
+    localStorage.setItem(TODOS_CACHE_KEY(uid), JSON.stringify(items))
+  } catch { /* ignore */ }
+}
 const newTodoText = ref('')
 const showAddPanel = ref(false)
 const notificationPermission = ref<NotificationPermission | 'unsupported'>('unsupported')
@@ -147,6 +165,13 @@ const updateBadge = (count: number) => {
 watch(incompleteCount, updateBadge, { immediate: true })
 
 const subscribeTodos = (uid: string) => {
+  // サーバー応答前にキャッシュを即時表示
+  const cached = loadCachedTodos(uid)
+  if (cached.length > 0) {
+    todos.value = cached
+  }
+  todosLoading.value = true
+
   const todosRef = collection(db, 'users', uid, 'todos')
   const q = query(todosRef, orderBy('createdAt', 'asc'))
   unsubscribeTodos = onSnapshot(q, (snapshot) => {
@@ -155,6 +180,8 @@ const subscribeTodos = (uid: string) => {
       text: doc.data().text as string,
       completed: doc.data().completed as boolean,
     }))
+    todosLoading.value = false
+    saveCachedTodos(uid, todos.value)
   })
 }
 
@@ -290,6 +317,7 @@ onMounted(() => {
       unsubscribeTodos()
       unsubscribeTodos = null
       todos.value = []
+      todosLoading.value = false
     }
 
     if (user) {
@@ -386,7 +414,7 @@ onUnmounted(() => {
         <span class="todo-text">{{ todo.text }}</span>
       </div>
 
-      <p v-if="todos.length === 0" class="empty-message">
+      <p v-if="todos.length === 0 && !todosLoading" class="empty-message">
         タスクがありません。＋ボタンで追加してください。
       </p>
     </div>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 起動時に Firestore からデータ取得完了前、一瞬タスクが空表示になる問題を修正
- 前回のタスク一覧を `localStorage` にキャッシュし、サーバー応答前に即時表示するよう対応
- Firestore の `onSnapshot` 受信後にキャッシュを更新することで常に最新状態を保持

## 変更内容

**`src/App.vue`**
- `todosLoading` フラグを追加（サーバー応答待ち中は `true`）
- `loadCachedTodos(uid)` / `saveCachedTodos(uid, items)` ヘルパーを追加
  - キャッシュキー: `todos_cache_{uid}`（ユーザーごとに分離）
  - `try/catch` でストレージ書き込み失敗を安全に無視
- `subscribeTodos` を修正：
  1. キャッシュがあれば即時 `todos.value` に反映
  2. `onSnapshot` 受信後にキャッシュ更新 & `todosLoading = false`
- ログアウト時に `todosLoading` をリセット
- 「タスクがありません」メッセージを `!todosLoading` のときのみ表示（サーバー取得完了前に誤表示しない）

## Test plan

- [ ] 初回ログイン後、タスクを追加して画面を確認
- [ ] ページリロード時にキャッシュから前回のタスクが即時表示されること
- [ ] Firestore からのデータ受信後、表示が最新状態に更新されること
- [ ] タスクが本当に 0 件の場合、「タスクがありません」メッセージが正しく表示されること
- [ ] ログアウト → 再ログイン時に正常に動作すること

https://claude.ai/code/session_01BmxR4CbMMtLGhZzXpfZ5vY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmxR4CbMMtLGhZzXpfZ5vY)_